### PR TITLE
Allow %var1 to be a Variable and not a Const, to fix bewec renderer with filters.

### DIFF
--- a/formbar/form.py
+++ b/formbar/form.py
@@ -894,6 +894,8 @@ class Field(object):
                     expr_str = expr_str.replace(x, value)
                 elif isinstance(value, basestring) and value.startswith("$"):
                     expr_str = expr_str.replace(x, "%s" % unicode(value))
+                elif isinstance(value, basestring) and value.startswith("*"):
+                    expr_str = expr_str.replace(x, "%s" % unicode(value))
                 else:
                     expr_str = expr_str.replace(x, "'%s'" % unicode(value))
         return Rule(expr_str.replace("*", "$"))


### PR DESCRIPTION
See issue2058.

Oh yes if *var1 is handled by the else path, it will be inserted into a Const brabbel node. And the filter will compare to different Const with EQ and always fail.

Found in bewec filter  "( %vorhaben == $vorhaben ) or ( $vorhaben == '0')".