### PR TITLE
fixed checkbox behaviour

### DIFF
--- a/formbar/static/js/formbar.js
+++ b/formbar/static/js/formbar.js
@@ -359,6 +359,7 @@ var form = function (inputFilter, ruleEngine) {
             var ftype = field.getAttribute("type");
             switch (ftype) {
                 case "checkbox":
+                    $("input[name='"+fieldName+"']:checked").each(function(){$(this).prop('checked', false)})
                     formFields[fieldName].value.forEach(function (x) { $("[name='"+fieldName+"'][value='" + x + "']").prop("checked", true); });
                     break;
                 case "radio":


### PR DESCRIPTION
The resetting of checkboxes had quirks.
It was done according to the reset of other input fields:
restoring the selected state.

This results in selecting the already selected checkboxes and neglecting the effect of newly selected checkboxes. With this fix, all checkboxes are cleared before reset.